### PR TITLE
Master

### DIFF
--- a/CreatureEditorAndPlugin/CreaturePlugin/Source/CreatureEditor/Private/CreatureAnimStateNode.cpp
+++ b/CreatureEditorAndPlugin/CreaturePlugin/Source/CreatureEditor/Private/CreatureAnimStateNode.cpp
@@ -35,7 +35,7 @@ void UCreatureAnimStateNode::PostEditChangeProperty(FPropertyChangedEvent& Prope
 
 void UCreatureAnimStateNode::Compile()
 {
-	CompiledState->AnimStateName = AnimName;
+	CompiledState->AnimStateName = FName(*AnimName);
 
 	CompiledState->TransitionList.Empty();
 	for (UEdGraphPin* Pin : Pins)
@@ -58,14 +58,12 @@ void UCreatureAnimStateNode::Compile()
 					//向状态机注册当前状态转换信息
 					CompiledState->TransitionList.Add(Tran);
 				}
-				
-
 			}
 		}
-
 	}
+
 	//如果是根节点,通知状态机
-	if (AnimName==FString(TEXT("Default")))
+	if (AnimName== TEXT("Default"))
 	{
 		CompiledState->AnimStateMachine->RootState = CompiledState;
 	}

--- a/CreatureEditorAndPlugin/CreaturePlugin/Source/CreatureEditor/Private/CreatureAnimStoreEditor.cpp
+++ b/CreatureEditorAndPlugin/CreaturePlugin/Source/CreatureEditor/Private/CreatureAnimStoreEditor.cpp
@@ -215,7 +215,7 @@ void SStoreDetailPanel::ConstructPreviewAnimationList()
 		PreviewAnimationNameList.Empty();
 		for (auto clip : EditorPtr.Pin()->GetEditingClipsStore()->ClipList)
 		{
-			TSharedPtr<FString> AnimName = MakeShareable(new FString(clip.ClipName));
+			TSharedPtr<FString> AnimName = MakeShareable(new FString(clip.ClipName.ToString()));
 			PreviewAnimationNameList.AddUnique(AnimName);
 		}
 	}

--- a/CreatureEditorAndPlugin/CreaturePlugin/Source/CreatureEditor/Private/CreatureAnimStoreEditorViewportClient.cpp
+++ b/CreatureEditorAndPlugin/CreaturePlugin/Source/CreatureEditor/Private/CreatureAnimStoreEditorViewportClient.cpp
@@ -84,7 +84,7 @@ void FCreatureAnimStoreEditorViewportClient::SetUpCamera()
 
 void FCreatureAnimStoreEditorViewportClient::ChangePreviewAnimation(FString AnimationName)
 {
-	EditingCreatureMesh->SetBluePrintActiveCollectionClip(AnimationName);
+	EditingCreatureMesh->SetBluePrintActiveCollectionClip(FName(*AnimationName));
 }
 
 void FCreatureAnimStoreEditorViewportClient::ReConstructMesh()

--- a/CreatureEditorAndPlugin/CreaturePlugin/Source/CreatureEditor/Public/CreatureAnimGraphSchema.h
+++ b/CreatureEditorAndPlugin/CreaturePlugin/Source/CreatureEditor/Public/CreatureAnimGraphSchema.h
@@ -36,9 +36,13 @@ struct FEdGraphSchemaAction_NewCreatureAnimationEndTransition : public FEdGraphS
 	}
 	virtual UEdGraphNode* PerformAction(class UEdGraph* ParentGraph, UEdGraphPin* FromPin, const FVector2D Location, bool bSelectNewNode = true) override;
 };
+
 UCLASS()
-class UCreatureAnimGraphSchema :public UEdGraphSchema{
+class CREATUREEDITOR_API  UCreatureAnimGraphSchema :public UEdGraphSchema{
 	GENERATED_BODY()
+
+protected:
+
 	// Begin UEdGraphSchema interface
 	virtual void CreateDefaultNodesForGraph(UEdGraph& Graph) const override;
 	virtual const FPinConnectionResponse CanCreateConnection(const UEdGraphPin* A, const UEdGraphPin* B) const override;
@@ -55,4 +59,6 @@ class UCreatureAnimGraphSchema :public UEdGraphSchema{
 	virtual void GetAssetsNodeHoverMessage(const TArray<FAssetData>& Assets, const UEdGraphNode* HoverNode, FString& OutTooltipText, bool& OutOkIcon) const override;
 	virtual void GetAssetsPinHoverMessage(const TArray<FAssetData>& Assets, const UEdGraphPin* HoverPin, FString& OutTooltipText, bool& OutOkIcon) const override;
 	// End UEdGraphSchema interface
+
+public:
 };

--- a/CreatureEditorAndPlugin/CreaturePlugin/Source/CreatureEditor/Public/CreatureAnimStateNode.h
+++ b/CreatureEditorAndPlugin/CreaturePlugin/Source/CreatureEditor/Public/CreatureAnimStateNode.h
@@ -10,17 +10,24 @@
 #include "CreatureAnimStateNode.generated.h"
 #pragma  once
 UCLASS()
-class UCreatureAnimStateNode :public UEdGraphNode{
+class CREATUREEDITOR_API UCreatureAnimStateNode :public UEdGraphNode
+{
 	GENERATED_BODY()
+
 public:
+
 	UPROPERTY()
 	TArray<UEdGraphPin*> InputPins;
+
 	UPROPERTY()
 	TArray<UEdGraphPin*> OutputPins;
+
 	UPROPERTY(EditAnyWhere, Category = "CreaturePlugin")
 	FString AnimName;
+
 	UPROPERTY()
-		UCreatureAnimState* CompiledState;
+	UCreatureAnimState* CompiledState;
+
 public:
 	UCreatureAnimStateNode()
 		:UEdGraphNode()
@@ -30,6 +37,7 @@ public:
 		AnimName = TEXT("DefaultAnimName");
 	
 	}
+
 	virtual void OnRenameNode(const FString& NewName)override;
 	virtual bool CanUserDeleteNode() const override;
 #ifdef WITH_EDITOR
@@ -37,10 +45,10 @@ public:
 #endif
 	
 	virtual FText GetNodeTitle(ENodeTitleType::Type TitleType) const override;
-	//初始化当前节点，产生一个临时（未连接）的CompiledState
+
 	void InitNode(class UCreatureAnimStateMachine*);
-	//编译当前状态节点
-	void Compile();
+
+	virtual void Compile();
 
 	virtual FLinearColor GetNodeTitleColor() const override;
 };

--- a/CreatureEditorAndPlugin/CreaturePlugin/Source/CreatureEditor/Public/CreatureStateMachineGraph.h
+++ b/CreatureEditorAndPlugin/CreaturePlugin/Source/CreatureEditor/Public/CreatureStateMachineGraph.h
@@ -9,7 +9,7 @@
 #include "CreatureStateMachineGraph.generated.h"
 #pragma once
 UCLASS()
-class  UCreatureStateMachineGraph :public UEdGraph{
+class CREATUREEDITOR_API UCreatureStateMachineGraph :public UEdGraph{
 	GENERATED_UCLASS_BODY()
 public:
 	UPROPERTY()

--- a/CreatureEditorAndPlugin/CreaturePlugin/Source/CreaturePlugin/Private/CreatureActor.cpp
+++ b/CreatureEditorAndPlugin/CreaturePlugin/Source/CreaturePlugin/Private/CreatureActor.cpp
@@ -129,13 +129,13 @@ ACreatureActor::GetCreatureManager()
 }
 
 void 
-ACreatureActor::MakeBluePrintPointCache(FString name_in, int32 approximation_level)
+ACreatureActor::MakeBluePrintPointCache(FName name_in, int32 approximation_level)
 {
 	creature_core.MakeBluePrintPointCache(name_in, approximation_level);
 }
 
 void 
-ACreatureActor::ClearBluePrintPointCache(FString name_in, int32 approximation_level)
+ACreatureActor::ClearBluePrintPointCache(FName name_in, int32 approximation_level)
 {
 	creature_core.ClearBluePrintPointCache(name_in, approximation_level);
 }
@@ -150,7 +150,7 @@ void ACreatureActor::BeginPlay()
 	Super::BeginPlay();
 }
 
-void ACreatureActor::SetBluePrintActiveAnimation(FString name_in)
+void ACreatureActor::SetBluePrintActiveAnimation(FName name_in)
 {
 	creature_core.SetBluePrintActiveAnimation(name_in);
 }
@@ -186,24 +186,24 @@ ACreatureActor::SetBluePrintAnimationPlayFromStart()
 }
 
 void 
-ACreatureActor::SetBluePrintAnimationCustomTimeRange(FString name_in, int32 start_time, int32 end_time)
+ACreatureActor::SetBluePrintAnimationCustomTimeRange(FName name_in, int32 start_time, int32 end_time)
 {
 	creature_core.SetBluePrintAnimationCustomTimeRange(name_in, start_time, end_time);
 }
 
-void ACreatureActor::SetBluePrintBlendActiveAnimation(FString name_in, float factor)
+void ACreatureActor::SetBluePrintBlendActiveAnimation(FName name_in, float factor)
 {
 	creature_core.SetBluePrintBlendActiveAnimation(name_in, factor);
 }
 
 void 
-ACreatureActor::SetBluePrintRegionAlpha(FString region_name_in, uint8 alpha_in)
+ACreatureActor::SetBluePrintRegionAlpha(FName region_name_in, uint8 alpha_in)
 {
 	creature_core.SetBluePrintRegionAlpha(region_name_in, alpha_in);
 }
 
 FTransform
-ACreatureActor::GetBluePrintBoneXform(FString name_in, bool world_transform, float position_slide_factor)
+ACreatureActor::GetBluePrintBoneXform(FName name_in, bool world_transform, float position_slide_factor)
 {
 	return creature_core.GetBluePrintBoneXform(name_in, world_transform, position_slide_factor, GetTransform());
 }
@@ -263,7 +263,6 @@ void ACreatureActor::Tick(float DeltaTime)
 		// Update Mesh
 		creature_mesh->SetBoundsScale(creature_bounds_scale);
 		creature_mesh->SetBoundsOffset(creature_bounds_offset);
-		creature_mesh->SetExtraXForm(GetTransform());
 
 		creature_mesh->SetTagString(GetName());
 		creature_mesh->ForceAnUpdate();
@@ -295,7 +294,7 @@ ACreatureActor::GetBluePrintAnimationFrame()
 	return creature_core.GetBluePrintAnimationFrame();
 }
 
-void ACreatureActor::SetBluePrintRegionCustomOrder(TArray<FString> order_in)
+void ACreatureActor::SetBluePrintRegionCustomOrder(TArray<FName> order_in)
 {
 	creature_core.SetBluePrintRegionCustomOrder(order_in);
 }

--- a/CreatureEditorAndPlugin/CreaturePlugin/Source/CreaturePlugin/Private/CreatureCollectionActor.cpp
+++ b/CreatureEditorAndPlugin/CreaturePlugin/Source/CreaturePlugin/Private/CreatureCollectionActor.cpp
@@ -106,7 +106,7 @@ void ACreatureCollectionActor::SetBluePrintActiveClip(FString clipName)
 }
 
 FTransform 
-ACreatureCollectionActor::GetBluePrintBoneXform(FString name_in, bool world_transform, float position_slide_factor)
+ACreatureCollectionActor::GetBluePrintBoneXform(FName name_in, bool world_transform, float position_slide_factor)
 {
 	if (collection_clips.count(active_clip_name))
 	{
@@ -128,7 +128,7 @@ void ACreatureCollectionActor::UpdateActorAnimationToStart(ACreatureCollectionCl
 	auto cur_actor = cur_data.first;
 
 	cur_actor = cur_data.first;
-	cur_actor->SetBluePrintActiveAnimation(FString(cur_data.second.c_str()));
+	cur_actor->SetBluePrintActiveAnimation(FName(cur_data.second.c_str()));
 	cur_actor->SetBluePrintAnimationResetToStart();
 }
 

--- a/CreatureEditorAndPlugin/CreaturePlugin/Source/CreaturePlugin/Private/CreatureCore.cpp
+++ b/CreatureEditorAndPlugin/CreaturePlugin/Source/CreaturePlugin/Private/CreatureCore.cpp
@@ -15,9 +15,14 @@ static std::string GetAnimationToken(const std::string& filename_in, const std::
 	return filename_in + std::string("_") + name_in;
 }
 
-std::string ConvertToString(FString str)
+std::string ConvertToString(const FString &str)
 {
 	std::string t = TCHAR_TO_UTF8(*str);
+	return t;
+}
+std::string ConvertToString(FName name)
+{
+	std::string t = TCHAR_TO_UTF8(*name.ToString());
 	return t;
 }
 
@@ -342,7 +347,7 @@ void CreatureCore::FillBoneData()
 	int i = 0;
 	for (auto& cur_data : bones_map)
 	{
-		bone_data[i].name = FString(cur_data.first.c_str());
+		bone_data[i].name = FName(cur_data.first.c_str());
 
 		auto pt1 = cur_data.second->getWorldStartPt();
 		auto pt2 = cur_data.second->getWorldEndPt();
@@ -648,21 +653,21 @@ CreatureCore::GetCreatureManager()
 }
 
 void 
-CreatureCore::SetBluePrintActiveAnimation(FString name_in)
+CreatureCore::SetBluePrintActiveAnimation(FName name_in)
 {
 	auto cur_str = ConvertToString(name_in);
 	SetActiveAnimation(cur_str);
 }
 
 void 
-CreatureCore::SetBluePrintBlendActiveAnimation(FString name_in, float factor)
+CreatureCore::SetBluePrintBlendActiveAnimation(FName name_in, float factor)
 {
 	auto cur_str = ConvertToString(name_in);
 	SetAutoBlendActiveAnimation(cur_str, factor);
 }
 
 void 
-CreatureCore::SetBluePrintAnimationCustomTimeRange(FString name_in, int32 start_time, int32 end_time)
+CreatureCore::SetBluePrintAnimationCustomTimeRange(FName name_in, int32 start_time, int32 end_time)
 {
 	auto cur_str = ConvertToString(name_in);
 	auto all_animations = creature_manager->GetAllAnimations();
@@ -674,12 +679,12 @@ CreatureCore::SetBluePrintAnimationCustomTimeRange(FString name_in, int32 start_
 }
 
 void 
-CreatureCore::MakeBluePrintPointCache(FString name_in, int32 approximation_level)
+CreatureCore::MakeBluePrintPointCache(FName name_in, int32 approximation_level)
 {
 	auto cur_creature_manager = GetCreatureManager();
 	if (!cur_creature_manager)
 	{
-		UE_LOG(LogTemp, Warning, TEXT("ACreatureActor::MakeBluePrintPointCache() - ERROR! Could not generate point cache for %s"), *name_in);
+		UE_LOG(LogTemp, Warning, TEXT("ACreatureActor::MakeBluePrintPointCache() - ERROR! Could not generate point cache for %s"), *name_in.ToString());
 		return;
 	}
 
@@ -697,12 +702,12 @@ CreatureCore::MakeBluePrintPointCache(FString name_in, int32 approximation_level
 }
 
 void 
-CreatureCore::ClearBluePrintPointCache(FString name_in, int32 approximation_level)
+CreatureCore::ClearBluePrintPointCache(FName name_in, int32 approximation_level)
 {
 	auto cur_creature_manager = GetCreatureManager();
 	if (!cur_creature_manager)
 	{
-		UE_LOG(LogTemp, Warning, TEXT("ACreatureActor::MakeBluePrintPointCache() - ERROR! Could not generate point cache for %s"), *name_in);
+		UE_LOG(LogTemp, Warning, TEXT("ACreatureActor::MakeBluePrintPointCache() - ERROR! Could not generate point cache for %s"), *name_in.ToString());
 		return;
 	}
 
@@ -710,7 +715,7 @@ CreatureCore::ClearBluePrintPointCache(FString name_in, int32 approximation_leve
 }
 
 FTransform 
-CreatureCore::GetBluePrintBoneXform(FString name_in, bool world_transform, float position_slide_factor, FTransform base_transform)
+CreatureCore::GetBluePrintBoneXform(FName name_in, bool world_transform, float position_slide_factor, FTransform base_transform)
 {
 	FTransform ret_xform;
 	for (size_t i = 0; i < bone_data.Num(); i++)
@@ -870,16 +875,32 @@ CreatureCore::SetBluePrintAnimationResetToStart()
 	play_end_done = false;
 }
 
-float 
+void CreatureCore::SetBluePrintAnimationResetToEnd()
+{
+	if (creature_manager) {
+		auto *anim = creature_manager->GetAnimation(creature_manager->GetActiveAnimationName());
+
+		float cur_runtime = anim->getEndTime();
+		creature_manager->setRunTime(cur_runtime);
+		animation_frame = cur_runtime;
+
+		creature_manager->Update(0.001f);
+	}
+
+	play_start_done = false;
+	play_end_done = false;
+}
+
+float
 CreatureCore::GetBluePrintAnimationFrame()
 {
 	return animation_frame;
 }
 
 void 
-CreatureCore::SetBluePrintRegionAlpha(FString region_name_in, uint8 alpha_in)
+CreatureCore::SetBluePrintRegionAlpha(FName region_name_in, uint8 alpha_in)
 {
-	if (region_name_in.IsEmpty())
+	if (region_name_in.IsNone())
 	{
 		return;
 	}
@@ -887,13 +908,13 @@ CreatureCore::SetBluePrintRegionAlpha(FString region_name_in, uint8 alpha_in)
 	region_alpha_map.Add(region_name_in, alpha_in);
 }
 
-void CreatureCore::RemoveBluePrintRegionAlpha(FString region_name_in)
+void CreatureCore::RemoveBluePrintRegionAlpha(FName region_name_in)
 {
 	region_alpha_map.Remove(region_name_in);
 }
 
 void 
-CreatureCore::SetBluePrintRegionCustomOrder(TArray<FString> order_in)
+CreatureCore::SetBluePrintRegionCustomOrder(TArray<FName> order_in)
 {
 	region_custom_order = order_in;
 }
@@ -904,12 +925,12 @@ CreatureCore::ClearBluePrintRegionCustomOrder()
 	region_custom_order.Empty();
 }
 
-void CreatureCore::SetBluePrintRegionItemSwap(FString region_name_in, int32 tag)
+void CreatureCore::SetBluePrintRegionItemSwap(FName region_name_in, int32 tag)
 {
 	creature_manager->GetCreature()->SetActiveItemSwap(ConvertToString(region_name_in), tag);
 }
 
-void CreatureCore::RemoveBluePrintRegionItemSwap(FString region_name_in)
+void CreatureCore::RemoveBluePrintRegionItemSwap(FName region_name_in)
 {
 	creature_manager->GetCreature()->RemoveActiveItemSwap(ConvertToString(region_name_in));
 }
@@ -923,8 +944,7 @@ bool CreatureCore::GetUseAnchorPoints() const
 {
 	return creature_manager->GetCreature()->GetAnchorPointsActive();
 }
-
-void 
+void
 CreatureCore::SetActiveAnimation(const std::string& name_in)
 {
 	creature_manager->SetActiveAnimationName(name_in);

--- a/CreatureEditorAndPlugin/CreaturePlugin/Source/CreaturePlugin/Private/CreatureMeshComponent.cpp
+++ b/CreatureEditorAndPlugin/CreaturePlugin/Source/CreaturePlugin/Private/CreatureMeshComponent.cpp
@@ -20,27 +20,27 @@ UCreatureMeshComponent::UCreatureMeshComponent(const FObjectInitializer& ObjectI
 	InitStandardValues();
 }
 
-void UCreatureMeshComponent::SetBluePrintActiveAnimation(FString name_in)
+void UCreatureMeshComponent::SetBluePrintActiveAnimation(FName name_in)
 {
 	creature_core.SetBluePrintActiveAnimation(name_in);
 }
 
-void UCreatureMeshComponent::SetBluePrintBlendActiveAnimation(FString name_in, float factor)
+void UCreatureMeshComponent::SetBluePrintBlendActiveAnimation(FName name_in, float factor)
 {
 	creature_core.SetBluePrintBlendActiveAnimation(name_in, factor);
 }
 
-void UCreatureMeshComponent::SetBluePrintAnimationCustomTimeRange(FString name_in, int32 start_time, int32 end_time)
+void UCreatureMeshComponent::SetBluePrintAnimationCustomTimeRange(FName name_in, int32 start_time, int32 end_time)
 {
 	creature_core.SetBluePrintAnimationCustomTimeRange(name_in, start_time, end_time);
 }
 
-void UCreatureMeshComponent::MakeBluePrintPointCache(FString name_in, int32 approximation_level)
+void UCreatureMeshComponent::MakeBluePrintPointCache(FName name_in, int32 approximation_level)
 {
 	creature_core.MakeBluePrintPointCache(name_in, approximation_level);
 }
 
-void UCreatureMeshComponent::ClearBluePrintPointCache(FString name_in, int32 approximation_level)
+void UCreatureMeshComponent::ClearBluePrintPointCache(FName name_in, int32 approximation_level)
 {
 	creature_core.ClearBluePrintPointCache(name_in, approximation_level);
 }
@@ -56,7 +56,7 @@ bool UCreatureMeshComponent::GetBluePrintUsePointCache()
 }
 
 FTransform 
-UCreatureMeshComponent::GetBluePrintBoneXform(FString name_in, bool world_transform, float position_slide_factor)
+UCreatureMeshComponent::GetBluePrintBoneXform(FName name_in, bool world_transform, float position_slide_factor)
 {
 	return creature_core.GetBluePrintBoneXform(name_in, world_transform, position_slide_factor, GetComponentToWorld());
 }
@@ -118,17 +118,17 @@ UCreatureMeshComponent::GetBluePrintAnimationFrame()
 	return creature_core.GetBluePrintAnimationFrame();
 }
 
-void UCreatureMeshComponent::SetBluePrintRegionAlpha(FString region_name_in, uint8 alpha_in)
+void UCreatureMeshComponent::SetBluePrintRegionAlpha(FName region_name_in, uint8 alpha_in)
 {
 	creature_core.SetBluePrintRegionAlpha(region_name_in, alpha_in);
 }
 
-void UCreatureMeshComponent::RemoveBluePrintRegionAlpha(FString region_name_in)
+void UCreatureMeshComponent::RemoveBluePrintRegionAlpha(FName region_name_in)
 {
 	creature_core.RemoveBluePrintRegionAlpha(region_name_in);
 }
 
-void UCreatureMeshComponent::SetBluePrintRegionCustomOrder(TArray<FString> order_in)
+void UCreatureMeshComponent::SetBluePrintRegionCustomOrder(TArray<FName> order_in)
 {
 	creature_core.SetBluePrintRegionCustomOrder(order_in);
 }
@@ -143,7 +143,7 @@ void UCreatureMeshComponent::SetIsDisabled(bool flag_in)
 	creature_core.SetIsDisabled(flag_in);
 }
 
-void UCreatureMeshComponent::SetBluePrintRegionItemSwap(FString region_name_in, int32 tag)
+void UCreatureMeshComponent::SetBluePrintRegionItemSwap(FName region_name_in, int32 tag)
 {
 	creature_core.SetBluePrintRegionItemSwap(region_name_in, tag);
 }
@@ -158,7 +158,7 @@ bool UCreatureMeshComponent::GetBluePrintUseAnchorPoints() const
 	return creature_core.GetUseAnchorPoints();
 }
 
-void UCreatureMeshComponent::RemoveBluePrintRegionItemSwap(FString region_name_in)
+void UCreatureMeshComponent::RemoveBluePrintRegionItemSwap(FName region_name_in)
 {
 	creature_core.RemoveBluePrintRegionItemSwap(region_name_in);
 }
@@ -206,16 +206,19 @@ void UCreatureMeshComponent::SetActiveCollectionAnimation(FCreatureMeshCollectio
 		RecreateRenderProxy(true);
 	}
 
-	SetMaterial(0, cur_data.collection_material);
-	if (localRenderProxy)
+	if (GetMaterial(0) != cur_data.collection_material)
 	{
-		localRenderProxy->SetNeedsMaterialUpdate(true);
+		SetMaterial(0, cur_data.collection_material);
+		if (localRenderProxy)
+		{
+			localRenderProxy->SetNeedsMaterialUpdate(true);
+		}
 	}
 
 	ForceAnUpdate(data_idx);
 }
 
-void UCreatureMeshComponent::SetBluePrintActiveCollectionClip(FString name_in)
+void UCreatureMeshComponent::SetBluePrintActiveCollectionClip(FName name_in)
 {
 	if (!enable_collection_playback)
 	{
@@ -287,10 +290,10 @@ void UCreatureMeshComponent::UpdateCoreValues()
 	creature_core.region_overlap_z_delta = region_overlap_z_delta;
 }
 
-void UCreatureMeshComponent::PrepareRenderData()
+void UCreatureMeshComponent::PrepareRenderData(CreatureCore &forCore)
 {
 	RecreateRenderProxy(true);
-	SetProceduralMeshTriData(creature_core.GetProcMeshData());
+	SetProceduralMeshTriData(forCore.GetProcMeshData());
 }
 
 void UCreatureMeshComponent::InitializeComponent()
@@ -363,10 +366,7 @@ UCreatureMeshComponent::RunCollectionTick(float DeltaTime)
 		return;
 	}
 
-	if (cur_data->animation_speed > 0)
-	{
-		true_delta_time = DeltaTime * cur_data->animation_speed;
-	}
+	true_delta_time *= cur_data->animation_speed;
 
 	if (active_collection_play == false)
 	{
@@ -389,7 +389,7 @@ UCreatureMeshComponent::RunCollectionTick(float DeltaTime)
 		bool announce_end = cur_core.GetAndClearShouldAnimEnd();
 
 		float cur_runtime = (cur_core.GetCreatureManager()->getActualRunTime());
-
+		
 		bool is_collection_start = (active_collection_clip->active_index == 0) && announce_start;
 		bool is_collection_end = (active_collection_clip->active_index == active_collection_clip->sequence_clips.Num() - 1) && announce_end;
 
@@ -440,6 +440,36 @@ UCreatureMeshComponent::RunCollectionTick(float DeltaTime)
 				SetActiveCollectionAnimation(active_collection_clip);
 			}
 		}
+		else if (next_time <= clip_animation->getStartTime())
+		{
+			// if we're going backwards, see if we should switch to the previous clip
+			// At the end of current clip, see if we should switch to the next clip
+			int next_active_index = active_collection_clip->active_index - 1;
+			int seq_num = active_collection_clip->sequence_clips.Num();
+			bool do_switch = false;
+			if (next_active_index < 0)
+			{
+				if (active_collection_loop)
+				{
+					active_collection_clip->active_index = seq_num - 1;
+					do_switch = true;
+				}
+			}
+			else {
+				active_collection_clip->active_index--;
+				do_switch = true;
+			}
+
+			if (do_switch)
+			{
+				SetActiveCollectionAnimation(active_collection_clip);
+
+				auto& cur_seq = active_collection_clip->sequence_clips[active_collection_clip->active_index];
+				auto data_idx = cur_seq.collection_data_index;
+				auto& cur_data = collectionData[data_idx];
+				cur_data.creature_core.SetBluePrintAnimationResetToEnd();
+			}
+		}
 
 		DoCreatureMeshUpdate(GetCollectionDataIndexFromClip(active_collection_clip));
 	}
@@ -458,7 +488,6 @@ void UCreatureMeshComponent::DoCreatureMeshUpdate(int render_packet_idx)
 	// Update Mesh
 	SetBoundsScale(creature_bounds_scale);
 	SetBoundsOffset(creature_bounds_offset);
-	SetExtraXForm(GetComponentToWorld());
 
 	ForceAnUpdate(render_packet_idx);
 
@@ -538,27 +567,32 @@ void UCreatureMeshComponent::OnRegister()
 {
 	Super::OnRegister();
 
-	StandardInit();
+	LoadAnimationFromStore();
+	if (enable_collection_playback)
+	{
+		CollectionInit();
+	}
+	else {
+		StandardInit();
+	}
 }
 
 void UCreatureMeshComponent::StandardInit()
 {
-	LoadAnimationFromStore();
 	UpdateCoreValues();
-
 	creature_core.do_file_warning = !enable_collection_playback;
 	bool retval = creature_core.InitCreatureRender();
 	creature_core.region_alpha_map.Empty();
 
 	if (retval)
 	{
-		PrepareRenderData();
-		RunTick(0.1f);
-		
-		if (!start_animation_name.IsEmpty())
+		if (!start_animation_name.IsNone())
 		{
 			SetBluePrintActiveAnimation(start_animation_name);
 		}
+
+		creature_core.SetBluePrintAnimationResetToStart();
+		PrepareRenderData(creature_core);
 	}
 }
 
@@ -602,12 +636,31 @@ void UCreatureMeshComponent::CollectionInit()
 					}
 				}
 			}
+
+			// needed to ensure point arrays have proper data
+			cur_core.SetBluePrintAnimationResetToStart();
 		}
 	}
 
-	if (!start_animation_name.IsEmpty())
+	if (!start_animation_name.IsNone())
 	{
+		active_collection_clip = nullptr;
+		active_collection_clip_name = NAME_None;
 		SetBluePrintActiveCollectionClip(start_animation_name);
+
+		if (active_collection_clip)
+		{
+			auto& cur_seq = active_collection_clip->sequence_clips[active_collection_clip->active_index];
+			auto data_idx = cur_seq.collection_data_index;
+
+			if (collectionData.IsValidIndex(data_idx))
+			{
+				auto& cur_data = collectionData[data_idx];
+
+				// prepare default render data to match code path of StandardInit
+				PrepareRenderData(collectionData[data_idx].creature_core);
+			}
+		}
 	}
 }
 
@@ -647,6 +700,7 @@ FPrimitiveSceneProxy* UCreatureMeshComponent::CreateSceneProxy()
 	}
 
 	render_proxy_ready = true;
+	ProcessCalcBounds(Proxy);
 
 	return Proxy;
 }
@@ -677,8 +731,32 @@ void UCreatureMeshComponent::LoadAnimationFromStore()
 	{
 		return;
 	}
+
 	collectionData.Empty();
 	collectionClips.Empty();
 	ClipStore->LoadAnimationDataToComponent(this);
+	
 	enable_collection_playback = true;
+
+	// previous pointers are now invalid
+	active_collection_clip = nullptr;
+	active_collection_clip_name = NAME_None;
+	FCProceduralMeshSceneProxy *localRenderProxy = GetLocalRenderProxy();
+	if (localRenderProxy)
+	{
+		localRenderProxy->ResetAllRenderPackets();
+
+		// Loop through and add in the collectionData
+		for (auto& cur_data : collectionData)
+		{
+			auto proc_mesh_data = cur_data.creature_core.GetProcMeshData();
+			if (proc_mesh_data.point_num > 0)
+			{
+				localRenderProxy->AddRenderPacket(&proc_mesh_data);
+			}
+		}
+
+		render_proxy_ready = true;
+		ProcessCalcBounds(localRenderProxy);
+	}
 }

--- a/CreatureEditorAndPlugin/CreaturePlugin/Source/CreaturePlugin/Private/CustomProceduralMeshComponent.cpp
+++ b/CreatureEditorAndPlugin/CreaturePlugin/Source/CreaturePlugin/Private/CustomProceduralMeshComponent.cpp
@@ -182,16 +182,15 @@ FCProceduralMeshSceneProxy::FCProceduralMeshSceneProxy(UCustomProceduralMeshComp
 	parentComponent = Component;
 	needs_updating = false;
 	needs_index_updating = false;
-	active_render_packet_idx = -1;
+	active_render_packet_idx = INDEX_NONE;
+
+	UpdateMaterial();
 
 	// Add each triangle to the vertex/index buffer
 	if (targetTrisIn)
 	{
 		AddRenderPacket(targetTrisIn);
-		active_render_packet_idx = 0;
 	}
-
-	UpdateMaterial();
 }
 
 FCProceduralMeshSceneProxy::~FCProceduralMeshSceneProxy()
@@ -264,6 +263,17 @@ void FCProceduralMeshSceneProxy::AddRenderPacket(FProceduralMeshTriData * target
 
 	// Enqueue initialization of render resource
 	cur_packet.InitForRender();
+
+	if (active_render_packet_idx == INDEX_NONE)
+	{
+		active_render_packet_idx = 0;
+	}
+}
+
+void FCProceduralMeshSceneProxy::ResetAllRenderPackets()
+{
+	renderPackets.Reset();
+	active_render_packet_idx = INDEX_NONE;
 }
 
 void FCProceduralMeshSceneProxy::SetActiveRenderPacketIdx(int idxIn)
@@ -431,10 +441,11 @@ void FCProceduralMeshSceneProxy::GetDynamicMeshElements(const TArray<const FScen
 FPrimitiveViewRelevance FCProceduralMeshSceneProxy::GetViewRelevance(const FSceneView* View) const
 {
 	FPrimitiveViewRelevance Result;
-	Result.bDrawRelevance = true; // IsShown(View);
+	Result.bDrawRelevance = true;// IsShown(View);
 	Result.bShadowRelevance = IsShadowCast(View);
 	Result.bDynamicRelevance = true;
 	MaterialRelevance.SetPrimitiveViewRelevance(Result);
+
 	return Result;
 }
 
@@ -461,7 +472,7 @@ UCustomProceduralMeshComponent::UCustomProceduralMeshComponent(const FObjectInit
 	: Super(ObjectInitializer)
 {
 	PrimaryComponentTick.bCanEverTick = false;
-	bounds_scale = 15.0f;
+	bounds_scale = 1.0f;
 	bounds_offset = FVector(0, 0, 0);
 	render_proxy_ready = false;
 	calc_local_vec_min = FVector(FLT_MIN, FLT_MIN, FLT_MIN);
@@ -522,7 +533,7 @@ UCustomProceduralMeshComponent::SetTagString(FString tag_in)
 FPrimitiveSceneProxy* UCustomProceduralMeshComponent::CreateSceneProxy()
 {
 	std::lock_guard<std::mutex> cur_lock(local_lock);
-
+	
 	FCProceduralMeshSceneProxy* Proxy = NULL;
 	// Only if have enough triangles
 	if(defaultTriData.point_num > 0)
@@ -531,7 +542,7 @@ FPrimitiveSceneProxy* UCustomProceduralMeshComponent::CreateSceneProxy()
 		render_proxy_ready = true;
 		ProcessCalcBounds(Proxy);
 	}
-
+	
 	return Proxy;
 }
 
@@ -556,7 +567,7 @@ void UCustomProceduralMeshComponent::ProcessCalcBounds(FCProceduralMeshSceneProx
 	const float bounds_max_scalar = 100000.0f;
 	calc_local_vec_min = FVector(-bounds_max_scalar, -bounds_max_scalar, -bounds_max_scalar);
 	calc_local_vec_max = FVector(bounds_max_scalar, bounds_max_scalar, bounds_max_scalar);
-
+	
 	// Only if have enough triangles
 	if (can_calc)
 	{
@@ -620,27 +631,25 @@ void UCustomProceduralMeshComponent::ProcessCalcBounds(FCProceduralMeshSceneProx
 			vecMax.Set(bounds_max_scalar, bounds_max_scalar, bounds_max_scalar);
 		}
 
-		FTransform curXForm = extraXForm;
-
-		vecMin = curXForm.TransformPosition(vecMin);
-		vecMax = curXForm.TransformPosition(vecMax);
-
 		calc_local_vec_min = vecMin;
 		calc_local_vec_max = vecMax;
 
 		debugSphere = FBoxSphereBounds(FBox(calc_local_vec_min, calc_local_vec_max)).GetSphere();
 	}
-
 }
 
 FBoxSphereBounds UCustomProceduralMeshComponent::CalcBounds(const FTransform & LocalToWorld) const
 {
-	auto ret_bounds = FBoxSphereBounds(FBox(calc_local_vec_min, calc_local_vec_max));
+	FBoxSphereBounds ret_bounds = FBoxSphereBounds(FBox(calc_local_vec_min, calc_local_vec_max));
+
 	if (ret_bounds.ContainsNaN())
 	{
 		ret_bounds = FBoxSphereBounds(FBox(FVector(-10000, -10000, -10000),
 			FVector(10000, 10000, 10000)));
 	}
+
+	// transform the bounds by the given transform
+	ret_bounds = ret_bounds.TransformBy(LocalToWorld);
 
 	return ret_bounds;
 }
@@ -655,16 +664,10 @@ void UCustomProceduralMeshComponent::SetBoundsOffset(const FVector& offset_in)
 	bounds_offset = offset_in;
 }
 
-void 
-UCustomProceduralMeshComponent::SetExtraXForm(const FTransform& xformIn)
-{
-	extraXForm = xformIn;
-}
-
 FSphere 
 UCustomProceduralMeshComponent::GetDebugBoundsSphere() const
 {
-	return debugSphere;
+	return debugSphere.TransformBy(GetComponentTransform());
 }
 
 /*

--- a/CreatureEditorAndPlugin/CreaturePlugin/Source/CreaturePlugin/Public/CreatureActor.h
+++ b/CreatureEditorAndPlugin/CreaturePlugin/Source/CreaturePlugin/Public/CreatureActor.h
@@ -95,32 +95,32 @@ public:
 
 	// Blueprint version of setting the active animation name
 	UFUNCTION(BlueprintCallable, Category = "Components|Creature")
-	void SetBluePrintActiveAnimation(FString name_in);
+	void SetBluePrintActiveAnimation(FName name_in);
 
 	// Blueprint version of setting the blended active animation name
 	UFUNCTION(BlueprintCallable, Category = "Components|Creature")
-	void SetBluePrintBlendActiveAnimation(FString name_in, float factor);
+	void SetBluePrintBlendActiveAnimation(FName name_in, float factor);
 
 	// Blueprint version of setting a custom time range for a given animation
 	UFUNCTION(BlueprintCallable, Category = "Components|Creature")
-	void SetBluePrintAnimationCustomTimeRange(FString name_in, int32 start_time, int32 end_time);
+	void SetBluePrintAnimationCustomTimeRange(FName name_in, int32 start_time, int32 end_time);
 
 	// Blueprint function to create a point cache for the creature character. This speeds up the playback performance.
 	// A small amount of time will be spent precomputing the point cache. You can reduce this time by increasing the approximation level.
 	// name_in is the name of the animation to cache, approximation_level is the approximation level. The higher the approximation level
 	// the faster the cache generation but lower the quality. 1 means no approximation, with 10 being the maximum value allowed.
 	UFUNCTION(BlueprintCallable, Category = "Components|Creature")
-	void MakeBluePrintPointCache(FString name_in, int32 approximation_level);
+	void MakeBluePrintPointCache(FName name_in, int32 approximation_level);
 
 	// Blueprint function to clear the point cache of a given animation
 	UFUNCTION(BlueprintCallable, Category = "Components|Creature")
-	void ClearBluePrintPointCache(FString name_in, int32 approximation_level);
+	void ClearBluePrintPointCache(FName name_in, int32 approximation_level);
 
 	// Blueprint function that returns the transform given a bone name, position_slide_factor
 	// determines how far left or right the transform is placed. The default value of 0 places it
 	// in the center of the bone, positve values places it to the right, negative to the left
 	UFUNCTION(BlueprintCallable, Category = "Components|Creature")
-	FTransform GetBluePrintBoneXform(FString name_in, bool world_transform, float position_slide_factor);
+	FTransform GetBluePrintBoneXform(FName name_in, bool world_transform, float position_slide_factor);
 
 	// BLueprint function that returns whether a given input point is colliding with any of the bones
 	UFUNCTION(BlueprintCallable, Category = "Components|Creature")
@@ -152,11 +152,11 @@ public:
 
 	// Blueprint function that sets the alpha(opacity value) of a region
 	UFUNCTION(BlueprintCallable, Category = "Components|Creature")
-	void SetBluePrintRegionAlpha(FString region_name_in, uint8 alpha_in);
+	void SetBluePrintRegionAlpha(FName region_name_in, uint8 alpha_in);
 
 	// Blueprint function that sets up a custom z order for the various regions
 	UFUNCTION(BlueprintCallable, Category = "Components|Creature")
-	void SetBluePrintRegionCustomOrder(TArray<FString> order_in);
+	void SetBluePrintRegionCustomOrder(TArray<FName> order_in);
 
 	// Blueprint function that clears the custom z order for the various regions
 	UFUNCTION(BlueprintCallable, Category = "Components|Creature")

--- a/CreatureEditorAndPlugin/CreaturePlugin/Source/CreaturePlugin/Public/CreatureAnimState.h
+++ b/CreatureEditorAndPlugin/CreaturePlugin/Source/CreaturePlugin/Public/CreatureAnimState.h
@@ -16,10 +16,10 @@ public:
 	TArray<UCreatureAnimTransition*> TransitionList;
 
 	UPROPERTY()
-	FString AnimStateName;
+	FName AnimStateName;
 
 public:
-	void BeginState(class UCreatureAnimStateMachineInstance *forInstance);
+	virtual void BeginState(class UCreatureAnimStateMachineInstance *forInstance);
 	void EndState(class UCreatureAnimStateMachineInstance *forInstance);
 	void CheckCondition(class UCreatureAnimStateMachineInstance *forInstance);
 	//Check if there is a 'AnimationEnd' Transition

--- a/CreatureEditorAndPlugin/CreaturePlugin/Source/CreaturePlugin/Public/CreatureAnimationAsset.h
+++ b/CreatureEditorAndPlugin/CreaturePlugin/Source/CreaturePlugin/Public/CreatureAnimationAsset.h
@@ -7,8 +7,9 @@
 #include "Engine.h"
 #include "CreatureAnimationAsset.generated.h"
 
+/** Container used to cache useful data about an animation, including it's point cache */
 USTRUCT()
-struct FCreatureAnimationPointsCache
+struct FCreatureAnimationDataCache
 {
 	GENERATED_BODY()
 
@@ -17,9 +18,12 @@ struct FCreatureAnimationPointsCache
 
 	UPROPERTY()
 	int32 m_numArrays;
-	
-	UPROPERTY()
-	FString m_animationName;
+
+	UPROPERTY(VisibleAnywhere, Category = Creature)
+	float m_length;
+
+	UPROPERTY(VisibleAnywhere, Category = Creature)
+	FName m_animationName;
 };
 
 UCLASS()
@@ -30,14 +34,10 @@ public:
 	FString GetCreatureFilename() const;
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Creature")
-	float animation_speed = 2.0f;
+	float animation_speed = 1.0f;
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Creature")
 	UMaterialInterface * collection_material;
-
-	//You can change an animation clip's scale to fix some problem
-	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Creature")
-	float Scale = 1.0f;
 
 	// Zip Binary Data
 	UPROPERTY()
@@ -49,9 +49,13 @@ public:
 	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category=Creature)
 	int32 m_pointsCacheApproximationLevel;
 
-	const FCreatureAnimationPointsCache *GetPointsCacheForClip(const FString & clipName) const;
+	const FCreatureAnimationDataCache *GetDataCacheForClip(const FName & clipName) const;
+
+	float GetClipLength(const FName & clipName) const;
 	void LoadPointCacheForAllClips(class CreatureCore *forCore) const;
-	void LoadPointCacheForClip(const FString &animName, class CreatureCore *forCore) const;
+	void LoadPointCacheForClip(const FName &animName, class CreatureCore *forCore) const;
+
+	virtual void Serialize(FArchive& Ar) override;
 
 #if WITH_EDITORONLY_DATA
 	void SetCreatureFilename(const FString &newFilename);
@@ -59,11 +63,7 @@ public:
 	void PostLoad() override;
 	void PreSave() override;
 	void PostInitProperties() override;
-
-	/** The names of all clips held in this asset, for reference (editor only) */
-	UPROPERTY(VisibleAnywhere, Category=Creature)
-	TArray<FString> m_clipNames;
-
+	
 	void GatherAnimationData();
 	
 protected:
@@ -82,7 +82,7 @@ protected:
 	UPROPERTY()
 	FString creature_filename;
 	
-	/** Cache of points for the animation clips, to improve runtime performance */
-	UPROPERTY()
-	TArray<FCreatureAnimationPointsCache> m_pointsCache;
+	/** Cache of useful data, including point cache, for the animation clips, to improve runtime performance */
+	UPROPERTY(VisibleAnywhere, Category = Creature)
+	TArray<FCreatureAnimationDataCache> m_dataCache;
 };

--- a/CreatureEditorAndPlugin/CreaturePlugin/Source/CreaturePlugin/Public/CreatureAnimationClip.h
+++ b/CreatureEditorAndPlugin/CreaturePlugin/Source/CreaturePlugin/Public/CreatureAnimationClip.h
@@ -14,12 +14,12 @@ USTRUCT()
 struct FCreatureAnimationShortClip
 {
 	GENERATED_USTRUCT_BODY()
-		//指向源AnimationAsset的指针
-		UPROPERTY(EditAnyWhere, BlueprintReadOnly, Category = "Creature")
-		UCreatureAnimationAsset* SourceAsset;
+	//指向源AnimationAsset的指针
+	UPROPERTY(EditAnyWhere, BlueprintReadOnly, Category = "Creature")
+	UCreatureAnimationAsset* SourceAsset;
 		
 	UPROPERTY(EditAnyWhere, BlueprintReadOnly, Category = "Creature")
-		FString ClipNameInAsset;
+	FName ClipNameInAsset;
 };
 //////////////////////////////////////////////////////////////////////////
 //真正的Clip片段
@@ -28,12 +28,12 @@ USTRUCT()
 struct FCreatureAnimationClip
 {
 	GENERATED_USTRUCT_BODY()
-		//指向源AnimationAsset的指针
-		UPROPERTY(EditAnyWhere, BlueprintReadOnly, Category = "Creature")
-		FString ClipName;
+	//指向源AnimationAsset的指针
+	UPROPERTY(EditAnyWhere, BlueprintReadOnly, Category = "Creature")
+	FName ClipName;
 
 	UPROPERTY(EditAnyWhere, BlueprintReadOnly, Category = "Creature")
-		TArray<FCreatureAnimationShortClip> ShortClipList;
+	TArray<FCreatureAnimationShortClip> ShortClipList;
 
 
 };

--- a/CreatureEditorAndPlugin/CreaturePlugin/Source/CreaturePlugin/Public/CreatureCollectionActor.h
+++ b/CreatureEditorAndPlugin/CreaturePlugin/Source/CreaturePlugin/Public/CreatureCollectionActor.h
@@ -82,7 +82,7 @@ public:
 	// determines how far left or right the transform is placed. The default value of 0 places it
 	// in the center of the bone, positve values places it to the right, negative to the left
 	UFUNCTION(BlueprintCallable, Category = "Components|Creature")
-	FTransform GetBluePrintBoneXform(FString name_in, bool world_transform, float position_slide_factor);
+	FTransform GetBluePrintBoneXform(FName name_in, bool world_transform, float position_slide_factor);
 
 	UPROPERTY(BlueprintAssignable, Category = "Components|Creature")
 	FCreatureAnimationCollectionEndEvent CreatureAnimationEndEvent;

--- a/CreatureEditorAndPlugin/CreaturePlugin/Source/CreaturePlugin/Public/CreatureCore.h
+++ b/CreatureEditorAndPlugin/CreaturePlugin/Source/CreaturePlugin/Public/CreatureCore.h
@@ -56,10 +56,10 @@ struct FCreatureBoneData
 	FTransform xform;
 	FTransform startXform;
 	FTransform endXform;
-	FString name;
+	FName name;
 };
 
-class CreatureCore {
+class CREATUREPLUGIN_API CreatureCore {
 public:
 	CreatureCore();
 
@@ -98,17 +98,17 @@ public:
 	// Returns the CreatureManager associated with this actor
 	CreatureModule::CreatureManager * GetCreatureManager();
 
-	void SetBluePrintActiveAnimation(FString name_in);
+	void SetBluePrintActiveAnimation(FName name_in);
 
-	void SetBluePrintBlendActiveAnimation(FString name_in, float factor);
+	void SetBluePrintBlendActiveAnimation(FName name_in, float factor);
 
-	void SetBluePrintAnimationCustomTimeRange(FString name_in, int32 start_time, int32 end_time);
+	void SetBluePrintAnimationCustomTimeRange(FName name_in, int32 start_time, int32 end_time);
 
-	void MakeBluePrintPointCache(FString name_in, int32 approximation_level);
+	void MakeBluePrintPointCache(FName name_in, int32 approximation_level);
 
-	void ClearBluePrintPointCache(FString name_in, int32 approximation_level);
+	void ClearBluePrintPointCache(FName name_in, int32 approximation_level);
 
-	FTransform GetBluePrintBoneXform(FString name_in, bool world_transform, float position_slide_factor, FTransform base_transform);
+	FTransform GetBluePrintBoneXform(FName name_in, bool world_transform, float position_slide_factor, FTransform base_transform);
 
 	bool IsBluePrintBonesCollide(FVector test_point, float bone_size, FTransform base_transform);
 
@@ -119,25 +119,26 @@ public:
 	void SetBluePrintAnimationPlayFromStart();
 
 	void SetBluePrintAnimationResetToStart();
+	void SetBluePrintAnimationResetToEnd();
 
 	float GetBluePrintAnimationFrame();
 
-	void SetBluePrintRegionAlpha(FString region_name_in, uint8 alpha_in);
+	void SetBluePrintRegionAlpha(FName region_name_in, uint8 alpha_in);
 
-	void RemoveBluePrintRegionAlpha(FString region_name_in);
+	void RemoveBluePrintRegionAlpha(FName region_name_in);
 
-	void SetBluePrintRegionCustomOrder(TArray<FString> order_in);
+	void SetBluePrintRegionCustomOrder(TArray<FName> order_in);
 
 	void ClearBluePrintRegionCustomOrder();
 
-	void SetBluePrintRegionItemSwap(FString region_name_in, int32 tag);
+	void SetBluePrintRegionItemSwap(FName region_name_in, int32 tag);
 
-	void RemoveBluePrintRegionItemSwap(FString region_name_in);
+	void RemoveBluePrintRegionItemSwap(FName region_name_in);
 
 	void SetUseAnchorPoints(bool flag_in);
 
 	bool GetUseAnchorPoints() const;
-
+	
 	void RunBeginPlay();
 
 	bool RunTick(float delta_time);
@@ -184,9 +185,9 @@ public:
 
 	TArray<uint8> region_alphas;
 
-	TMap<FString, uint8> region_alpha_map;
+	TMap<FName, uint8> region_alpha_map;
 
-	TArray<FString> region_custom_order;
+	TArray<FName> region_custom_order;
 
 	FString absolute_creature_filename;
 
@@ -218,4 +219,5 @@ public:
 	std::shared_ptr<glm::uint32> global_indices_copy;
 };
 
-std::string ConvertToString(FString str);
+std::string ConvertToString(const FString &str);
+std::string ConvertToString(FName name);

--- a/CreatureEditorAndPlugin/CreaturePlugin/Source/CreaturePlugin/Public/CreatureMeshComponent.h
+++ b/CreatureEditorAndPlugin/CreaturePlugin/Source/CreaturePlugin/Public/CreatureMeshComponent.h
@@ -51,7 +51,7 @@ struct FCreatureMeshCollectionToken
 	GENERATED_USTRUCT_BODY()
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Components|Creature")
-	FString animation_name;
+	FName animation_name;
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Components|Creature")
 	int32 collection_data_index;
@@ -63,7 +63,7 @@ struct FCreatureMeshCollectionClip
 	GENERATED_USTRUCT_BODY()
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Components|Creature")
-	FString collection_name;
+	FName collection_name;
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Components|Creature")
 	TArray<FCreatureMeshCollectionToken> sequence_clips;
@@ -168,7 +168,7 @@ public:
 
 	/** Starting animation clip */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Components|Creature")
-	FString start_animation_name;
+	FName start_animation_name;
 
 	/** Current frame of the animation during playback */
 	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Components|Creature")
@@ -203,26 +203,26 @@ public:
 
 	// Blueprint version of setting the active animation name
 	UFUNCTION(BlueprintCallable, Category = "Components|Creature")
-	void SetBluePrintActiveAnimation(FString name_in);
+	void SetBluePrintActiveAnimation(FName name_in);
 
 	// Blueprint version of setting the blended active animation name
 	UFUNCTION(BlueprintCallable, Category = "Components|Creature")
-	void SetBluePrintBlendActiveAnimation(FString name_in, float factor);
+	void SetBluePrintBlendActiveAnimation(FName name_in, float factor);
 
 	// Blueprint version of setting a custom time range for a given animation
 	UFUNCTION(BlueprintCallable, Category = "Components|Creature")
-	void SetBluePrintAnimationCustomTimeRange(FString name_in, int32 start_time, int32 end_time);
+	void SetBluePrintAnimationCustomTimeRange(FName name_in, int32 start_time, int32 end_time);
 
 	// Blueprint function to create a point cache for the creature character. This speeds up the playback performance.
 	// A small amount of time will be spent precomputing the point cache. You can reduce this time by increasing the approximation level.
 	// name_in is the name of the animation to cache, approximation_level is the approximation level. The higher the approximation level
 	// the faster the cache generation but lower the quality. 1 means no approximation, with 10 being the maximum value allowed.
 	UFUNCTION(BlueprintCallable, Category = "Components|Creature")
-	void MakeBluePrintPointCache(FString name_in, int32 approximation_level);
+	void MakeBluePrintPointCache(FName name_in, int32 approximation_level);
 
 	// Blueprint function to clear the point cache of a given animation
 	UFUNCTION(BlueprintCallable, Category = "Components|Creature")
-	void ClearBluePrintPointCache(FString name_in, int32 approximation_level);
+	void ClearBluePrintPointCache(FName name_in, int32 approximation_level);
 
 	// Blueprint function to enable/disable the use of all point caching on this mesh
 	UFUNCTION(BlueprintCallable, Category = "Components|Creature")
@@ -236,7 +236,7 @@ public:
 	// determines how far left or right the transform is placed. The default value of 0 places it
 	// in the center of the bone, positve values places it to the right, negative to the left
 	UFUNCTION(BlueprintCallable, Category = "Components|Creature")
-	FTransform GetBluePrintBoneXform(FString name_in, bool world_transform, float position_slide_factor);
+	FTransform GetBluePrintBoneXform(FName name_in, bool world_transform, float position_slide_factor);
 
 	// Blueprint function that decides whether the animation will loop or not
 	UFUNCTION(BlueprintCallable, Category = "Components|Creature")
@@ -264,15 +264,15 @@ public:
 
 	// Blueprint function that sets the alpha(opacity value) of a region
 	UFUNCTION(BlueprintCallable, Category = "Components|Creature")
-	void SetBluePrintRegionAlpha(FString region_name_in, uint8 alpha_in);
+	void SetBluePrintRegionAlpha(FName region_name_in, uint8 alpha_in);
 
 	// Blueprint function that removes the custom override alpha(opacity value) of a region
 	UFUNCTION(BlueprintCallable, Category = "Components|Creature")
-	void RemoveBluePrintRegionAlpha(FString region_name_in);
+	void RemoveBluePrintRegionAlpha(FName region_name_in);
 
 	// Blueprint function that sets up a custom z order for the various regions
 	UFUNCTION(BlueprintCallable, Category = "Components|Creature")
-	void SetBluePrintRegionCustomOrder(TArray<FString> order_in);
+	void SetBluePrintRegionCustomOrder(TArray<FName> order_in);
 
 	// Blueprint function that clears the custom z order for the various regions
 	UFUNCTION(BlueprintCallable, Category = "Components|Creature")
@@ -284,15 +284,15 @@ public:
 
 	// Blueprint function that sets the active collection clip
 	UFUNCTION(BlueprintCallable, Category = "Components|Creature")
-	void SetBluePrintRegionItemSwap(FString region_name_in, int32 tag);
+	void SetBluePrintRegionItemSwap(FName region_name_in, int32 tag);
 
 	// Blueprint function that sets the active collection clip
 	UFUNCTION(BlueprintCallable, Category = "Components|Creature")
-	void RemoveBluePrintRegionItemSwap(FString region_name_in);
+	void RemoveBluePrintRegionItemSwap(FName region_name_in);
 
 	// Blueprint function that sets the active collection clip
 	UFUNCTION(BlueprintCallable, Category = "Components|Creature")
-	void SetBluePrintActiveCollectionClip(FString name_in);
+	void SetBluePrintActiveCollectionClip(FName name_in);
 
 	// Blueprint function that activates/deactivates the usage of anchor points exported into the asset. If active, the character will be translated relative to the anchor point defined for it.
 	UFUNCTION(BlueprintCallable, Category = "Components|Creature")
@@ -301,8 +301,7 @@ public:
 	// Blueprint function that returns whether anchor points are active for the character
 	UFUNCTION(BlueprintCallable, Category = "Components|Creature")
 	bool GetBluePrintUseAnchorPoints() const;
-
-
+	
 	CreatureCore& GetCore();
 
 	virtual void TickComponent(float DeltaTime, enum ELevelTick TickType, FActorComponentTickFunction *ThisTickFunction) override;
@@ -332,7 +331,7 @@ public:
 protected:
 
 	CreatureCore creature_core;
-	FString active_collection_clip_name;
+	FName active_collection_clip_name;
 	FCreatureMeshCollectionClip * active_collection_clip;
 	bool active_collection_loop;
 	bool active_collection_play;
@@ -341,7 +340,7 @@ protected:
 
 	void UpdateCoreValues();
 
-	void PrepareRenderData();
+	void PrepareRenderData(CreatureCore &forCore);
 
 	void RunTick(float DeltaTime);
 
@@ -353,7 +352,7 @@ protected:
 
 	void SwitchToCollectionClip(FCreatureMeshCollectionClip * clip_in);
 
-	void SetActiveCollectionAnimation(FCreatureMeshCollectionClip * clip_in);
+	virtual void SetActiveCollectionAnimation(FCreatureMeshCollectionClip * clip_in);
 
 	FCreatureMeshCollection *
 	GetCollectionDataFromClip(FCreatureMeshCollectionClip * clip_in);

--- a/CreatureEditorAndPlugin/CreaturePlugin/Source/CreaturePlugin/Public/CustomProceduralMeshComponent.h
+++ b/CreatureEditorAndPlugin/CreaturePlugin/Source/CreaturePlugin/Public/CustomProceduralMeshComponent.h
@@ -56,7 +56,8 @@ public:
 
 	void AddRenderPacket(FProceduralMeshTriData * targetTrisIn);
 
-
+	void ResetAllRenderPackets();
+	
 	void SetActiveRenderPacketIdx(int idxIn);
 
 	void UpdateDynamicIndexData();
@@ -134,7 +135,7 @@ struct FProceduralMeshTriangle
 
 /** Component that allows you to specify custom triangle mesh geometry */
 UCLASS(editinlinenew, meta = (BlueprintSpawnableComponent), ClassGroup=Rendering)
-class UCustomProceduralMeshComponent : public UMeshComponent //, public IInterface_CollisionDataProvider
+class CREATUREPLUGIN_API UCustomProceduralMeshComponent : public UMeshComponent //, public IInterface_CollisionDataProvider
 {
 	GENERATED_UCLASS_BODY()
 
@@ -170,8 +171,6 @@ public:
 
 	FSphere GetDebugBoundsSphere() const;
 
-	void SetExtraXForm(const FTransform& xformIn);
-
 	void SetBoundsScale(float value_in);
 
 	void SetBoundsOffset(const FVector& offset_in);
@@ -185,7 +184,6 @@ public:
 
 protected:
 	FProceduralMeshTriData defaultTriData;
-	FTransform extraXForm;
 	FString tagStr;
 
 	void ProcessCalcBounds(FCProceduralMeshSceneProxy *localRenderProxy);


### PR DESCRIPTION
Converted most uses of FString to FName;
Added API and virtual keywords in some useful places;
Added support for backwards playback to collection clips;
Creature assets only store point cache in cooked builds;
Mesh component bounds calculation now takes into account render transform correctly;
Fixed instances where collection data pointers would dangle after data was reloaded;
Initialization code path now more similar between meshes that use collection clips and those that don't;
Meshes that use collection clips now correctly render in preview windows
