### PR TITLE
Async Performance optimizations v2.0

### DIFF
--- a/CreatureEditorAndPlugin/CreaturePlugin/Source/CreatureEditor/Private/CreatureAnimationAssetFactory.cpp
+++ b/CreatureEditorAndPlugin/CreaturePlugin/Source/CreatureEditor/Private/CreatureAnimationAssetFactory.cpp
@@ -43,7 +43,7 @@ UObject* UCreatureAnimationAssetFactory::FactoryCreateNew(UClass* Class, UObject
 
 bool UCreatureAnimationAssetFactory::ImportSourceFile(UCreatureAnimationAsset *forAsset) const
 {
-	FString creatureFilename = forAsset->GetCreatureFilename().ToString();
+	FString creatureFilename = forAsset->UpdateAndGetCreatureFilename().ToString();
 	if (forAsset == nullptr || creatureFilename.IsEmpty())
 	{
 		return false;
@@ -93,7 +93,7 @@ bool UCreatureAnimationAssetFactory::CanReimport(UObject* Obj, TArray<FString>& 
 	UCreatureAnimationAsset* asset = Cast<UCreatureAnimationAsset>(Obj);
 	if (asset)
 	{
-		FString filename = asset->GetCreatureFilename().ToString();
+		FString filename = asset->UpdateAndGetCreatureFilename().ToString();
 		if (!filename.IsEmpty())
 		{
 			OutFilenames.Add(filename);

--- a/CreatureEditorAndPlugin/CreaturePlugin/Source/CreatureEditor/Private/CreatureAnimationAssetTypeActions.cpp
+++ b/CreatureEditorAndPlugin/CreaturePlugin/Source/CreatureEditor/Private/CreatureAnimationAssetTypeActions.cpp
@@ -33,7 +33,7 @@ void FCreatureAnimationAssetTypeActions::GetResolvedSourceFilePaths(const TArray
 
 		if (animAsset != nullptr)
 		{
-			const FName &filename = animAsset->GetCreatureFilename();
+			const FName &filename = animAsset->UpdateAndGetCreatureFilename();
 			if (!filename.IsNone())
 			{
 				OutSourceFilePaths.Add(filename.ToString());

--- a/CreatureEditorAndPlugin/CreaturePlugin/Source/CreaturePlugin/Private/CreatureAnimationAsset.cpp
+++ b/CreatureEditorAndPlugin/CreaturePlugin/Source/CreaturePlugin/Private/CreatureAnimationAsset.cpp
@@ -3,9 +3,9 @@
 #include "CreatureAnimationAsset.h"
 #include "CreatureCore.h"
 
-FName UCreatureAnimationAsset::GetCreatureFilename() const
-{
 #if WITH_EDITORONLY_DATA
+FName UCreatureAnimationAsset::UpdateAndGetCreatureFilename()
+{
 	TArray<FString> filenames;
 	if (AssetImportData)
 	{
@@ -13,15 +13,15 @@ FName UCreatureAnimationAsset::GetCreatureFilename() const
 	}
 	if (filenames.Num() > 0)
 	{
-		return FName(*filenames[0]);
+		creature_filename = FName(*filenames[0]);
 	}
-	else
-	{
-		return creature_filename;
-	}
-#else
 	return creature_filename;
+}
 #endif
+
+FName UCreatureAnimationAsset::GetCreatureFilename() const
+{
+	return creature_filename;
 }
 
 bool 
@@ -199,7 +199,7 @@ void UCreatureAnimationAsset::PostLoad()
 void UCreatureAnimationAsset::GatherAnimationData()
 {
 	// ensure the filenames are synced
-	creature_filename = GetCreatureFilename();
+	creature_filename = UpdateAndGetCreatureFilename();
 	
 	// load the JSON data into creature so we can extract the animation names and generate the point caches for the anims
 	CreatureCore creature_core;

--- a/CreatureEditorAndPlugin/CreaturePlugin/Source/CreaturePlugin/Private/CreatureCore.cpp
+++ b/CreatureEditorAndPlugin/CreaturePlugin/Source/CreaturePlugin/Private/CreatureCore.cpp
@@ -28,31 +28,6 @@ std::string ConvertToString(FName name)
 	return t;
 }
 
-typedef std::chrono::high_resolution_clock Time;
-static auto profileTimeStart = Time::now();
-static auto profileTimeEnd = Time::now();
-
-static void StartProfileTimer()
-{
-	typedef std::chrono::milliseconds ms;
-	typedef std::chrono::duration<float> fsec;
-
-	profileTimeStart = Time::now();
-}
-
-static float StopProfileTimer()
-{
-	typedef std::chrono::milliseconds ms;
-	typedef std::chrono::duration<float> fsec;
-
-	profileTimeEnd = Time::now();
-
-	fsec fs = profileTimeEnd - profileTimeStart;
-	ms d = std::chrono::duration_cast<ms>(fs);
-	auto time_passed_fs = fs.count();
-	return time_passed_fs * 1000.0f;
-}
-
 CreatureCore::CreatureCore()
 {
 	pJsonData = nullptr;
@@ -73,7 +48,7 @@ CreatureCore::CreatureCore()
 	should_update_render_indices = false;
 	meta_data = nullptr;
 	global_indices_copy = nullptr;
-	update_lock = new std::mutex();
+	update_lock = TSharedPtr<FCriticalSection, ESPMode::ThreadSafe>(new FCriticalSection());
 }
 
 CreatureCore::~CreatureCore()
@@ -87,6 +62,7 @@ CreatureCore::ClearMemory()
 	if (global_indices_copy)
 	{
 		delete[] global_indices_copy;
+		global_indices_copy = nullptr;
 	}
 }
 
@@ -717,6 +693,13 @@ CreatureCore::SetBluePrintBlendActiveAnimation(FName name_in, float factor)
 void 
 CreatureCore::SetBluePrintAnimationCustomTimeRange(FName name_in, int32 start_time, int32 end_time)
 {
+	auto cur_creature_manager = GetCreatureManager();
+	if (!cur_creature_manager)
+	{
+		UE_LOG(LogTemp, Warning, TEXT("CreatureCore::SetBluePrintAnimationCustomTimeRange() - ERROR! no CreatureManager"), *name_in.ToString());
+		return;
+	}
+
 	auto cur_str = name_in;
 	auto all_animations = creature_manager->GetAllAnimations();
 	if (all_animations.Contains(cur_str))
@@ -732,7 +715,7 @@ CreatureCore::MakeBluePrintPointCache(FName name_in, int32 approximation_level)
 	auto cur_creature_manager = GetCreatureManager();
 	if (!cur_creature_manager)
 	{
-		UE_LOG(LogTemp, Warning, TEXT("ACreatureActor::MakeBluePrintPointCache() - ERROR! Could not generate point cache for %s"), *name_in.ToString());
+		UE_LOG(LogTemp, Warning, TEXT("CreatureCore::MakeBluePrintPointCache - ERROR! Could not generate point cache for %s"), *name_in.ToString());
 		return;
 	}
 
@@ -763,7 +746,7 @@ CreatureCore::ClearBluePrintPointCache(FName name_in, int32 approximation_level)
 }
 
 FTransform 
-CreatureCore::GetBluePrintBoneXform(FName name_in, bool world_transform, float position_slide_factor, FTransform base_transform)
+CreatureCore::GetBluePrintBoneXform(FName name_in, bool world_transform, float position_slide_factor, FTransform base_transform) const
 {
 	FTransform ret_xform;
 	for (size_t i = 0; i < bone_data.Num(); i++)
@@ -851,7 +834,7 @@ CreatureCore::RunTick(float delta_time)
 {
 	SCOPE_CYCLE_COUNTER(STAT_CreatureCore_RunTick);
 
-	std::lock_guard<std::mutex> scope_lock(*update_lock);
+	FScopeLock scope_lock(update_lock.Get());
 
 	if (is_driven)
 	{
@@ -904,6 +887,8 @@ CreatureCore::SetBluePrintAnimationPlay(bool flag_in)
 void 
 CreatureCore::SetBluePrintAnimationPlayFromStart()
 {
+	FScopeLock scope_lock(update_lock.Get());
+
 	SetBluePrintAnimationResetToStart();
 	SetBluePrintAnimationPlay(true);
 }
@@ -911,6 +896,8 @@ CreatureCore::SetBluePrintAnimationPlayFromStart()
 void 
 CreatureCore::SetBluePrintAnimationResetToStart()
 {
+	FScopeLock scope_lock(update_lock.Get());
+
 	if (creature_manager.Get()) {
 		creature_manager->ResetToStartTimes();
 		float cur_runtime = (creature_manager->getActualRunTime());

--- a/CreatureEditorAndPlugin/CreaturePlugin/Source/CreaturePlugin/Private/CustomProceduralMeshComponent.cpp
+++ b/CreatureEditorAndPlugin/CreaturePlugin/Source/CreaturePlugin/Private/CustomProceduralMeshComponent.cpp
@@ -9,6 +9,11 @@
 
 DECLARE_DWORD_COUNTER_STAT(TEXT("Creature Mesh Tris"), STAT_CreatureMeshTriangles, STATGROUP_Creature);
 DECLARE_CYCLE_STAT(TEXT("ProceduralMeshSceneProxy_GetDynamicMeshElements"), STAT_ProceduralMeshSceneProxy_GetDynamicMeshElements, STATGROUP_Creature);
+DECLARE_CYCLE_STAT(TEXT("ProceduralMeshSceneProxy_SetDynamicData"), STAT_ProceduralMeshSceneProxy_SetDynamicData, STATGROUP_Creature);
+
+DECLARE_CYCLE_STAT(TEXT("Creature CreateDirectVertexData"), STAT_CreateDirectVertexData, STATGROUP_Creature);
+DECLARE_CYCLE_STAT(TEXT("Creature UpdateDirectVertexData"), STAT_UpdateDirectVertexData, STATGROUP_Creature);
+DECLARE_CYCLE_STAT(TEXT("Creature UpdateDirectIndexData"), STAT_UpdateDirectIndexData, STATGROUP_Creature);
 
 static TAutoConsoleVariable<int32> CVarShowCreatureMeshes(
 	TEXT("creature.ShowMeshes"),
@@ -110,6 +115,9 @@ public:
 		region_alphas = data_in->region_alphas;
 		update_lock = data_in->update_lock;
 		should_release = false;
+
+		// ensure the vertex data to be sent to the RHI is initialized
+		CreateDirectVertexData();
 	}
 
 	virtual ~FProceduralMeshRenderPacket()
@@ -130,49 +138,73 @@ public:
 		should_release = true;
 	}
 
-	void UpdateDirectVertexData() const
+	TArray<FDynamicMeshVertex> VertexCache;
+
+	void CreateDirectVertexData()
 	{
+		SCOPE_CYCLE_COUNTER(STAT_CreateDirectVertexData);
+
 		const int x_id = 0;
 		const int y_id = 2;
 		const int z_id = 1;
 
-		std::lock_guard<std::mutex> scope_lock(*update_lock);
-
-		FDynamicMeshVertex* VertexBufferData = (FDynamicMeshVertex *)RHILockVertexBuffer(VertexBuffer.VertexBufferRHI, 0, this->point_num * sizeof(FDynamicMeshVertex), RLM_WriteOnly);
+		FScopeLock scope_lock(update_lock.Get());
+		
+		if (VertexCache.Num() != point_num)
+		{
+			VertexCache.Reset(point_num);
+			VertexCache.AddUninitialized(point_num);
+		}
 
 		for (int32 i = 0; i < this->point_num; i++)
 		{
-			FDynamicMeshVertex* curVert = VertexBufferData + i;
+			FDynamicMeshVertex& curVert = VertexCache[i];
 
 			int pos_idx = i * 3;
-			curVert->Position = FVector(this->points[pos_idx + x_id],
+			curVert.Position = FVector(this->points[pos_idx + x_id],
 				this->points[pos_idx + y_id],
 				this->points[pos_idx + z_id]);
 
 			float set_alpha = (*this->region_alphas)[i];
-			curVert->Color = FColor(set_alpha, set_alpha, set_alpha, set_alpha);
+			curVert.Color = FColor(set_alpha, set_alpha, set_alpha, set_alpha);
 
 			int uv_idx = i * 2;
-			curVert->TextureCoordinate.Set(this->uvs[uv_idx], this->uvs[uv_idx + 1]);
+			curVert.TextureCoordinate.Set(this->uvs[uv_idx], this->uvs[uv_idx + 1]);
 		}
 
 		// Set Tangents
-		for (int cur_indice = 0; cur_indice < indices_num; cur_indice+=3)
+		for (int cur_indice = 0; cur_indice < indices_num; cur_indice += 3)
 		{
-			FDynamicMeshVertex * vert0 = VertexBufferData + (indices[cur_indice]);
-			FDynamicMeshVertex * vert1 = VertexBufferData + (indices[cur_indice + 1]);
-			FDynamicMeshVertex * vert2 = VertexBufferData + (indices[cur_indice + 2]);
+			FDynamicMeshVertex & vert0 = VertexCache[(indices[cur_indice])];
+			FDynamicMeshVertex & vert1 = VertexCache[(indices[cur_indice+1])];
+			FDynamicMeshVertex & vert2 = VertexCache[(indices[cur_indice+2])];
 
-			const FVector Edge01 = (vert1->Position - vert0->Position);
-			const FVector Edge02 = (vert2->Position - vert0->Position);
+			const FVector Edge01 = (vert1.Position - vert0.Position);
+			const FVector Edge02 = (vert2.Position - vert0.Position);
 
 			const FVector TangentX = Edge01.GetSafeNormal();
 			const FVector TangentZ = (Edge02 ^ Edge01).GetSafeNormal();
 			const FVector TangentY = (TangentX ^ TangentZ).GetSafeNormal();
 
-			vert0->SetTangents(TangentX, TangentY, TangentZ);
-			vert1->SetTangents(TangentX, TangentY, TangentZ);
-			vert2->SetTangents(TangentX, TangentY, TangentZ);
+			vert0.SetTangents(TangentX, TangentY, TangentZ);
+			vert1.SetTangents(TangentX, TangentY, TangentZ);
+			vert2.SetTangents(TangentX, TangentY, TangentZ);
+		}
+
+	}
+
+	void UpdateDirectVertexData() const
+	{
+		SCOPE_CYCLE_COUNTER(STAT_UpdateDirectVertexData);
+		
+		int32 numReadyVertices = VertexCache.Num();
+		check(numReadyVertices == point_num);
+
+		FDynamicMeshVertex* VertexBufferData = (FDynamicMeshVertex *)RHILockVertexBuffer(VertexBuffer.VertexBufferRHI, 0, numReadyVertices * sizeof(FDynamicMeshVertex), RLM_WriteOnly);
+
+		{
+			FScopeLock scope_lock(update_lock.Get());
+			FMemory::Memcpy(VertexBufferData, &VertexCache[0], numReadyVertices * sizeof(FDynamicMeshVertex));
 		}
 
 		RHIUnlockVertexBuffer(VertexBuffer.VertexBufferRHI);
@@ -180,7 +212,9 @@ public:
 
 	void UpdateDirectIndexData() const
 	{
-		std::lock_guard<std::mutex> scope_lock(*update_lock);
+		SCOPE_CYCLE_COUNTER(STAT_UpdateDirectIndexData);
+
+		FScopeLock scope_lock(update_lock.Get());
 		void* Buffer = RHILockIndexBuffer(IndexBuffer.IndexBufferRHI, 0, indices_num * sizeof(int32), RLM_WriteOnly);
 
 		FMemory::Memcpy(Buffer, indices, indices_num * sizeof(int32));
@@ -196,7 +230,7 @@ public:
 	glm::float32 * uvs;
 	int32 point_num, indices_num;
 	TArray<uint8> * region_alphas;
-	std::mutex * update_lock;
+	TSharedPtr<FCriticalSection, ESPMode::ThreadSafe> update_lock;
 	bool should_release;
 };
 
@@ -208,7 +242,6 @@ FCProceduralMeshSceneProxy::FCProceduralMeshSceneProxy(UCustomProceduralMeshComp
 	MaterialRelevance(Component->GetMaterialRelevance(GetScene().GetFeatureLevel()))
 {
 	parentComponent = Component;
-	needs_updating = true;
 	needs_index_updating = false;
 	active_render_packet_idx = INDEX_NONE;
 
@@ -236,6 +269,11 @@ FCProceduralMeshSceneProxy::GetActiveRenderPacket()
 	return &renderPackets[active_render_packet_idx];
 }
 
+bool FCProceduralMeshSceneProxy::GetDoesActiveRenderPacketHaveVertices() const
+{
+	return renderPackets.IsValidIndex(active_render_packet_idx) && renderPackets[active_render_packet_idx].VertexCache.Num() > 0;
+}
+
 void FCProceduralMeshSceneProxy::UpdateMaterial()
 {
 	// Grab material
@@ -244,10 +282,14 @@ void FCProceduralMeshSceneProxy::UpdateMaterial()
 	{
 		Material = UMaterial::GetDefaultMaterial(MD_Surface);
 	}
+
+	needs_material_updating = false;
 }
 
 void FCProceduralMeshSceneProxy::AddRenderPacket(FProceduralMeshTriData * targetTrisIn)
 {
+	FScopeLock packetLock(&renderPacketsCS);
+
 	FProceduralMeshRenderPacket new_packet(targetTrisIn);
 	renderPackets.Add(new_packet);
 
@@ -318,12 +360,15 @@ void FCProceduralMeshSceneProxy::AddRenderPacket(FProceduralMeshTriData * target
 
 void FCProceduralMeshSceneProxy::ResetAllRenderPackets()
 {
+	FScopeLock packetLock(&renderPacketsCS);
+
 	renderPackets.Reset();
 	active_render_packet_idx = INDEX_NONE;
 }
 
 void FCProceduralMeshSceneProxy::SetActiveRenderPacketIdx(int idxIn)
 {
+	FScopeLock packetLock(&renderPacketsCS);
 	active_render_packet_idx = idxIn;
 }
 
@@ -338,6 +383,12 @@ void FCProceduralMeshSceneProxy::UpdateDynamicComponentData()
 	{
 		UpdateMaterial();
 	}
+
+	FScopeLock packetLock(&renderPacketsCS);
+
+	auto& cur_packet = renderPackets[active_render_packet_idx];
+
+	cur_packet.CreateDirectVertexData();
 
 	/*
 	auto& cur_packet = renderPackets[active_render_packet_idx];
@@ -386,15 +437,6 @@ void FCProceduralMeshSceneProxy::UpdateDynamicComponentData()
 		cnter++;
 	}
 	*/
-
-	needs_updating = true;
-}
-
-void FCProceduralMeshSceneProxy::DoneUpdating()
-{
-	needs_updating = false;
-	needs_index_updating = false;
-	needs_material_updating = false;
 }
 
 void FCProceduralMeshSceneProxy::SetNeedsMaterialUpdate(bool flag_in)
@@ -405,6 +447,27 @@ void FCProceduralMeshSceneProxy::SetNeedsMaterialUpdate(bool flag_in)
 void FCProceduralMeshSceneProxy::SetNeedsIndexUpdate(bool flag_in)
 {
 	needs_index_updating = flag_in;
+}
+
+void FCProceduralMeshSceneProxy::SetDynamicData_RenderThread()
+{
+	SCOPE_CYCLE_COUNTER(STAT_ProceduralMeshSceneProxy_SetDynamicData);
+
+	FScopeLock packetLock(&renderPacketsCS);
+
+	if (active_render_packet_idx < 0)
+	{
+		return;
+	}
+
+	auto& cur_packet = renderPackets[active_render_packet_idx];
+
+	cur_packet.UpdateDirectVertexData();
+	if (needs_index_updating) 
+	{
+		cur_packet.UpdateDirectIndexData();
+		needs_index_updating = false;
+	}
 }
 
 void FCProceduralMeshSceneProxy::GetDynamicMeshElements(const TArray<const FSceneView*>& Views,
@@ -426,6 +489,8 @@ void FCProceduralMeshSceneProxy::GetDynamicMeshElements(const TArray<const FScen
 		return;
 	}
 
+	FScopeLock packetLock(&renderPacketsCS);
+
 	auto& cur_packet = renderPackets[active_render_packet_idx];
 	auto& VertexBuffer = cur_packet.VertexBuffer;
 	auto& IndexBuffer = cur_packet.IndexBuffer;
@@ -436,16 +501,7 @@ void FCProceduralMeshSceneProxy::GetDynamicMeshElements(const TArray<const FScen
 	{
 		return;
 	}
-
-	if (needs_updating) {
-		cur_packet.UpdateDirectVertexData();
-		if (needs_index_updating) {
-			cur_packet.UpdateDirectIndexData();
-		}
-	}
-
-	(const_cast<FCProceduralMeshSceneProxy*>(this))->DoneUpdating();
-	
+			
 	const bool bWireframe = AllowDebugViewmodes() && ViewFamily.EngineShowFlags.Wireframe;
 
 	auto WireframeMaterialInstance = new FColoredMaterialRenderProxy(
@@ -557,24 +613,44 @@ bool UCustomProceduralMeshComponent::SetProceduralMeshTriData(const FProceduralM
 	return true;
 }
 
+void UCustomProceduralMeshComponent::SendRenderDynamicData_Concurrent()
+{
+	FCProceduralMeshSceneProxy *proxy = GetLocalRenderProxy();
+	if (proxy)
+	{
+		// Enqueue command to send to render thread
+		ENQUEUE_UNIQUE_RENDER_COMMAND_ONEPARAMETER(
+			FSendCreatureDynamicData,
+			FCProceduralMeshSceneProxy*, sceneProxy, proxy,
+			{
+				sceneProxy->SetDynamicData_RenderThread();
+			});
+	}
+}
+
 void UCustomProceduralMeshComponent::RecreateRenderProxy(bool flag_in)
 {
 	recreate_render_proxy = flag_in;
 }
 
-void UCustomProceduralMeshComponent::ForceAnUpdate(int render_packet_idx)
+void UCustomProceduralMeshComponent::ForceAnUpdate(int render_packet_idx, bool markDirty /*= true*/)
 {
+	FScopeLock cur_lock(&local_lock);
+
 	// Need to recreate scene proxy to send it over
 	if (recreate_render_proxy)
 	{
-		MarkRenderStateDirty();
-		recreate_render_proxy = false;
+		if (markDirty)
+		{
+			MarkRenderStateDirty();
+			recreate_render_proxy = false;
+		}
 		return;
 	}
 
-	std::lock_guard<std::mutex> cur_lock(local_lock);
 	FCProceduralMeshSceneProxy *localRenderProxy = GetLocalRenderProxy();
-	if (render_proxy_ready && localRenderProxy) {
+	if (render_proxy_ready && localRenderProxy)
+	{
 		if (render_packet_idx >= 0)
 		{
 			localRenderProxy->SetActiveRenderPacketIdx(render_packet_idx);
@@ -582,7 +658,13 @@ void UCustomProceduralMeshComponent::ForceAnUpdate(int render_packet_idx)
 
 		localRenderProxy->UpdateDynamicComponentData();
 		ProcessCalcBounds(localRenderProxy);
-		MarkRenderTransformDirty();
+
+		if (markDirty)
+		{
+			MarkRenderTransformDirty();
+			
+			MarkRenderDynamicDataDirty();
+		}
 	}
 }
 
@@ -594,14 +676,18 @@ UCustomProceduralMeshComponent::SetTagString(FString tag_in)
 
 FPrimitiveSceneProxy* UCustomProceduralMeshComponent::CreateSceneProxy()
 {
-	std::lock_guard<std::mutex> cur_lock(local_lock);
+	FScopeLock cur_lock(&local_lock);
 	
 	FCProceduralMeshSceneProxy* Proxy = NULL;
 	// Only if have enough triangles
 	if(defaultTriData.point_num > 0)
 	{
 		Proxy = new FCProceduralMeshSceneProxy(this, &defaultTriData);
+
+		SendRenderDynamicData_Concurrent();
+
 		render_proxy_ready = true;
+
 		ProcessCalcBounds(Proxy);
 	}
 	

--- a/CreatureEditorAndPlugin/CreaturePlugin/Source/CreaturePlugin/Public/CreatureAnimationAsset.h
+++ b/CreatureEditorAndPlugin/CreaturePlugin/Source/CreaturePlugin/Public/CreatureAnimationAsset.h
@@ -64,6 +64,7 @@ public:
 	virtual void Serialize(FArchive& Ar) override;
 
 #if WITH_EDITORONLY_DATA
+	FName UpdateAndGetCreatureFilename();
 	void SetCreatureFilename(const FName &newFilename);
 	void GetAssetRegistryTags(TArray<FAssetRegistryTag>& OutTags) const override;
 	void PostLoad() override;

--- a/CreatureEditorAndPlugin/CreaturePlugin/Source/CreaturePlugin/Public/CreatureCore.h
+++ b/CreatureEditorAndPlugin/CreaturePlugin/Source/CreaturePlugin/Public/CreatureCore.h
@@ -39,7 +39,6 @@
 #include "CreatureModule.h"
 #include <Runtime/Engine/Classes/Engine/EngineTypes.h>
 #include <vector>
-#include <mutex>
 #include <memory>
 
 // Creature Core is a thin wrapper between the Creature Runtime and any UE4 Creature Object(s)
@@ -121,7 +120,7 @@ public:
 
 	void ClearBluePrintPointCache(FName name_in, int32 approximation_level);
 
-	FTransform GetBluePrintBoneXform(FName name_in, bool world_transform, float position_slide_factor, FTransform base_transform);
+	FTransform GetBluePrintBoneXform(FName name_in, bool world_transform, float position_slide_factor, FTransform base_transform) const;
 
 	bool IsBluePrintBonesCollide(FVector test_point, float bone_size, FTransform base_transform);
 
@@ -223,7 +222,7 @@ public:
 
 	bool should_update_render_indices;
 
-	std::mutex * update_lock;
+	TSharedPtr<FCriticalSection, ESPMode::ThreadSafe> update_lock;
 
 	//////////////////////////////////////////////////////////////////////////
 	//Add by God of Pen

--- a/CreatureEditorAndPlugin/CreaturePlugin/Source/CreaturePlugin/Public/CustomProceduralMeshComponent.h
+++ b/CreatureEditorAndPlugin/CreaturePlugin/Source/CreaturePlugin/Public/CustomProceduralMeshComponent.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <mutex>
 #include  <glm/glm.hpp>
 #include "CustomProceduralMeshComponent.generated.h"
 
@@ -25,7 +24,7 @@ public:
 		int32 point_num_in,
 		int32 indices_num_in,
 		TArray<uint8> * region_alphas_in,
-		std::mutex * update_lock_in)
+		TSharedPtr<FCriticalSection, ESPMode::ThreadSafe> update_lock_in)
 	{
 		indices = indices_in;
 		points = points_in;
@@ -41,7 +40,7 @@ public:
 	glm::float32 * uvs;
 	int32 point_num, indices_num;
 	TArray<uint8> * region_alphas;
-	std::mutex * update_lock;
+	TSharedPtr<FCriticalSection, ESPMode::ThreadSafe> update_lock;
 };
 
 /** Scene proxy */
@@ -67,9 +66,7 @@ public:
 	void SetNeedsIndexUpdate(bool flag_in);
 
 	void UpdateMaterial();
-
-	void DoneUpdating();
-
+	
 	virtual void GetDynamicMeshElements(const TArray<const FSceneView*>& Views,
 		const FSceneViewFamily& ViewFamily,
 		uint32 VisibilityMap,
@@ -85,6 +82,9 @@ public:
 	uint32 GetAllocatedSize(void) const;
 
 	FProceduralMeshRenderPacket * GetActiveRenderPacket();
+	bool GetDoesActiveRenderPacketHaveVertices() const;
+
+	void SetDynamicData_RenderThread();
 
 private:
 	UCustomProceduralMeshComponent* parentComponent;
@@ -93,9 +93,10 @@ private:
 	int active_render_packet_idx;
 
 	FMaterialRelevance MaterialRelevance;
-	bool needs_updating;
 	bool needs_index_updating;
 	bool needs_material_updating;
+
+	mutable FCriticalSection renderPacketsCS;
 };
 
 USTRUCT(BlueprintType)
@@ -139,7 +140,7 @@ class CREATUREPLUGIN_API UCustomProceduralMeshComponent : public UMeshComponent 
 
 public:
 
-	void ForceAnUpdate(int render_packet_idx=-1);
+	void ForceAnUpdate(int render_packet_idx=-1, bool markDirty = true);
 
 	/** Description of collision */
 	UPROPERTY(BlueprintReadOnly, Category="Collision")
@@ -179,6 +180,8 @@ public:
 
 	bool SetProceduralMeshTriData(const FProceduralMeshTriData& TriData);
 
+	/** Called to send dynamic data for this component to the rendering thread */
+	virtual void SendRenderDynamicData_Concurrent() override;
 
 protected:
 	FProceduralMeshTriData defaultTriData;
@@ -203,6 +206,6 @@ protected:
 		return (FCProceduralMeshSceneProxy*)SceneProxy;
 	}
 	bool render_proxy_ready;
-	std::mutex local_lock;
+	FCriticalSection local_lock;
 	bool recreate_render_proxy;
 };

--- a/CreatureEditorAndPlugin/CreaturePlugin/Source/CreaturePlugin/Public/MeshBone.h
+++ b/CreatureEditorAndPlugin/CreaturePlugin/Source/CreaturePlugin/Public/MeshBone.h
@@ -583,7 +583,7 @@ protected:
     int32 start_time, end_time;
     bool is_ready;
     
-    std::mutex data_lock;
+    FCriticalSection data_lock;
 };
 
 class meshDisplacementCacheManager {
@@ -650,7 +650,7 @@ protected:
     int32 start_time, end_time;
     bool is_ready;
     
-    std::mutex data_lock;
+	FCriticalSection data_lock;
 };
 
 class meshUVWarpCacheManager {
@@ -709,7 +709,7 @@ protected:
     int32 start_time, end_time;
     bool is_ready;
     
-    std::mutex data_lock;
+	FCriticalSection data_lock;
 };
 
 class meshOpacityCacheManager {
@@ -766,7 +766,7 @@ protected:
 	int32 start_time, end_time;
 	bool is_ready;
 
-	std::mutex data_lock;
+	FCriticalSection data_lock;
 };
 
 


### PR DESCRIPTION
- Replaced use of std::mutex with epic's FCriticalSection
- Fixed memoryleak where mutex owned by CreatureCore would never be
destroyed by switching to TSharedPtr
- Improved performance of UCreatureMeshComponent::UpdateCoreValues by
checking if update is required before doing it
- Added stat counters throughout module
- Implemented
UCustomProceduralMeshComponent::SendRenderDynamicData_Concurrent and
moved update of RHI buffers there to a RenderThread task
- Moved call to creature_core.RunTick and caching processing of Vertex
buffers to a TaskGraph async that's checked at the end of the frame
- RenderThread task only does a memcpy