### PR TITLE
fix CreaturePlugin build error on Clang/Linux

### DIFF
--- a/CreatureEditorAndPlugin/CreaturePlugin/Source/CreatureEditor/Private/CreatureToolsDetails.cpp
+++ b/CreatureEditorAndPlugin/CreaturePlugin/Source/CreatureEditor/Private/CreatureToolsDetails.cpp
@@ -112,7 +112,7 @@ FReply FCreatureToolsDetails::LiveSyncPressed()
 		}
 	}
 
-	auto retrieve_filename = FString(creatureClient_retrieveRequestExportFilename("REQUEST_JSON"));
+	auto retrieve_filename = FString(creatureClient_retrieveRequestExportFilename((char *)"REQUEST_JSON"));
 
 	if (retrieve_filename.IsEmpty())
 	{


### PR DESCRIPTION
I'm using UE 4.15 branch from GitHub on a Clang/Funtoo Linux combination which gives me the following error when I try to build the plugin. This pull request solved that for me.

```
Plugins/CreaturePlugin/Source/CreatureEditor/Private/CreatureToolsDetails.cpp:115:80: error: 
      ISO C++11 does not allow conversion from string literal to 'char *'
      [-Werror,-Wwritable-strings]
  ...= FString(creatureClient_retrieveRequestExportFilename("REQUEST_JSON"));
```