### PR TITLE
Small usability fixes

### DIFF
--- a/CreatureEditorAndPlugin/CreaturePlugin/Source/CreaturePlugin/Private/CreatureCore.cpp
+++ b/CreatureEditorAndPlugin/CreaturePlugin/Source/CreaturePlugin/Private/CreatureCore.cpp
@@ -442,7 +442,8 @@ void CreatureCore::ParseEvents(float deltaTime)
 		if ((cur_runtime + 1.0f >= cur_end_time)
 			&& !is_looping
 			&& !play_end_done
-			&& should_play)
+			&& should_play
+			&& deltaTime > 0.0f)
 		{
 			play_end_done = true;
 			should_play = false;
@@ -681,6 +682,18 @@ CreatureCore::SetBluePrintAnimationCustomTimeRange(FName name_in, int32 start_ti
 	}
 }
 
+void CreatureCore::SetTimeScale(float timeScale)
+{
+	auto cur_creature_manager = GetCreatureManager();
+	if (!cur_creature_manager)
+	{
+		UE_LOG(LogTemp, Warning, TEXT("CreatureCore::SetTimeScale() - ERROR! no CreatureManager"));
+		return;
+	}
+
+	cur_creature_manager->SetTimeScale(timeScale);
+}
+
 void 
 CreatureCore::MakeBluePrintPointCache(FName name_in, int32 approximation_level)
 {
@@ -911,8 +924,9 @@ CreatureCore::GetBluePrintAnimationFrame()
 
 void CreatureCore::SetBluePrintAnimationFrame(float time_in)
 {
-	auto cur_delta = (time_in - creature_manager->getActualRunTime()) / 30.0f;
+	auto cur_delta = (time_in - creature_manager->getActualRunTime()) / creature_manager->GetTimeScale();
 	creature_manager->Update(cur_delta);
+	animation_frame = creature_manager->getActualRunTime();
 }
 
 void 

--- a/CreatureEditorAndPlugin/CreaturePlugin/Source/CreaturePlugin/Private/CreatureModule.cpp
+++ b/CreatureEditorAndPlugin/CreaturePlugin/Source/CreaturePlugin/Private/CreatureModule.cpp
@@ -1319,6 +1319,12 @@ namespace CreatureModule {
     {
         time_scale = scale_in;
     }
+
+	float
+	CreatureManager::GetTimeScale() const
+	{
+		return time_scale;
+	}
     
     void
     CreatureManager::SetBlending(bool flag_in)

--- a/CreatureEditorAndPlugin/CreaturePlugin/Source/CreaturePlugin/Public/CreatureCore.h
+++ b/CreatureEditorAndPlugin/CreaturePlugin/Source/CreaturePlugin/Public/CreatureCore.h
@@ -120,6 +120,8 @@ public:
 
 	void SetBluePrintAnimationCustomTimeRange(FName name_in, int32 start_time, int32 end_time);
 
+	void SetTimeScale(float timeScale);
+
 	void MakeBluePrintPointCache(FName name_in, int32 approximation_level);
 
 	void ClearBluePrintPointCache(FName name_in, int32 approximation_level);

--- a/CreatureEditorAndPlugin/CreaturePlugin/Source/CreaturePlugin/Public/CreatureModule.h
+++ b/CreatureEditorAndPlugin/CreaturePlugin/Source/CreaturePlugin/Public/CreatureModule.h
@@ -287,6 +287,9 @@ namespace CreatureModule {
         
         // Sets scaling for time
         void SetTimeScale(float scale_in);
+
+		// Gets scaling for time
+		float GetTimeScale() const;
         
         // Enables/Disables blending
         void SetBlending(bool flag_in);


### PR DESCRIPTION
- Exposed CreatureManager's timescale to creaturecore API
- Fix for issue where calling GetBluePrintAnimationFrame immediately
after calling SetBluePrintAnimationFrame would not return the newly set
value
- Fix for issue where attempting to play an animation backwards from the
end would cause it to immediately end